### PR TITLE
make it run on nodejs 0.10 from Debian 8

### DIFF
--- a/src/meshpinger.js
+++ b/src/meshpinger.js
@@ -127,7 +127,7 @@ function runPinger(endpoint, interval, callback) {
     setInterval(function () {
         const msg = moment.utc().toISOString() + '\t' + hostname + '\t' + count++;
 
-        client.send(msg, 0, msg.length, port, address, function (err) {
+        client.send(new Buffer(msg), 0, msg.length, port, address, function (err) {
             if (err) {
                 callback('send-failed', endpoint);
             }


### PR DESCRIPTION
without the change I get

dgram.js:248
    throw new TypeError('First argument must be a buffer object.');
          ^
TypeError: First argument must be a buffer object.
    at Socket.send (dgram.js:248:11)
    at null.<anonymous> (/home/thk/MeshPinger/src/meshpinger.js:130:16)
    at wrapper [as _onTimeout] (timers.js:258:14)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)